### PR TITLE
Add support for internal transactions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'httparty'
-gem 'ynab', '1.3.0'
+gem 'ynab', '1.5.0'
 
 # Dumper: BBVA
 gem 'bankscrap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff
     webrobots (0.1.2)
-    ynab (1.3.0)
+    ynab (1.5.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
@@ -135,7 +135,7 @@ DEPENDENCIES
   twentysix
   vcr
   webmock
-  ynab (= 1.3.0)
+  ynab (= 1.5.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ The script also includes some additional logic like detecting internal transacti
 
 # Known Problems
 
-* Internal transactions _(transfer from one account to an other one)_ don't work yet. This is because the official YNAB API doesn't support the creation of internal transactions yet. They announced [here](https://support.youneedabudget.com/t/18pw4x?pg=1#x12hlq) that they're working on it 🎉.
-
-> **Workaround:** the script flags those transactions in orange, so you can quickly see them and manually edit them to be an internal transaction.
+* Currently no known problems
 
 ____________________
 

--- a/lib/transaction_creator.rb
+++ b/lib/transaction_creator.rb
@@ -81,8 +81,7 @@ class TransactionCreator
       nil
     end
 
-    def flag_color(options)
-      return 'orange' if internal_account_id(options)
+    def flag_color(_options)
       nil
     end
 

--- a/spec/dumper/n26_spec.rb
+++ b/spec/dumper/n26_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe Dumper::N26, vcr: vcr_options do
   describe '#fetch_transactions' do
     subject(:method) { object.fetch_transactions }
 
+    before do
+      allow(TransactionCreator).to(
+        receive(:find_payee_id_by_account_id)
+        .and_return('12345')
+      )
+    end
+
     it 'sets the transactions' do
       expect(method).to be_truthy
     end

--- a/spec/fixtures/vcr_cassettes/TransactionCreator/_find_payee_id_by_account_id/returns_the_correct_account_id.yml
+++ b/spec/fixtures/vcr_cassettes/TransactionCreator/_find_payee_id_by_account_id/returns_the_correct_account_id.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.youneedabudget.com/v1/budgets/b01bcd86-1905-11e8-ad03-2b62fa19f158/accounts/ebec22d4-1905-11e8-8a4c-7b32b5a7e49f
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - api_client/ruby/1.5.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 123456789
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Fri, 28 Sep 2018 20:37:17 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Rate-Limit:
+      - 2/200
+      Vary:
+      - Accept-Encoding, Origin
+      Etag:
+      - W/"b2af3a7fd0da15ba3779d251a6863d0c"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 4792d1df-0622-468c-8753-79692230cf55
+      X-Runtime:
+      - '0.037224'
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"account":{"id":"DE89370400440532013000","name":"MyBank
+        Giro","type":"checking","on_budget":true,"closed":false,"note":"MyBank Giro","balance":111,"cleared_balance":111,"uncleared_balance":0,"transfer_payee_id":"57244b6e-c35e-11e8-8178-8f80c501f13b","deleted":false}}}'
+    http_version:
+  recorded_at: Fri, 28 Sep 2018 20:37:18 GMT
+recorded_with: VCR 4.0.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'vcr'
 
+ENV['ENV'] = 'test'
+
 Dir[File.dirname(__FILE__) + '/lib/*.rb'].each { |f| require f }
 Dir[File.join('.', 'lib/**/*.rb')].each { |f| require f }
 

--- a/spec/transaction_creator_spec.rb
+++ b/spec/transaction_creator_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe TransactionCreator do
-  describe '#call' do
+  describe '.call' do
     subject(:call) do
       described_class.call(
         account_id: '123456789',
@@ -32,6 +32,71 @@ RSpec.describe TransactionCreator do
         'payee_id'    => nil,
         'payee_name'  => 'Payee'
       )
+    end
+  end
+
+  describe '.payee_id' do
+    subject(:method) { described_class.payee_id(options) }
+
+    let(:payee_id) { nil }
+    let(:options) { { payee_id: payee_id } }
+
+    context 'when payee_id is set' do
+      let(:payee_id) { '12345678' }
+
+      it 'returns that payee_id' do
+        expect(method).to eq(payee_id)
+      end
+    end
+
+    context 'when transaction is a withdrawal?' do
+      before do
+        allow(described_class).to receive(:withdrawal?).and_return(true)
+      end
+
+      it 'returns that payee_id' do
+        expect(method).to eq('b4fb2fd6-1905-11e8-98a1-b3e93d6cc9e2')
+      end
+    end
+
+    context 'when transaction is an internal transfer' do
+      before do
+        allow(described_class).to receive(:internal_account_id)
+          .and_return('12345')
+      end
+
+      it 'returns that payee_id' do
+        expect(method).to eq('12345')
+      end
+    end
+
+    context 'when nothing relevant is set' do
+      it 'returns nil' do
+        expect(method).to be_nil
+      end
+    end
+  end
+
+  describe '.internal_account_id' do
+    subject(:method) { described_class.internal_account_id(options) }
+
+    let(:options) { { payee_iban: payee_iban } }
+
+    context 'when the transfer is an internal transfer' do
+      let(:payee_iban) { 'DE89370400440532013000' }
+      let(:expected_account_id) { 'ebec22d4-1905-11e8-8a4c-7b32b5a7e49f' }
+
+      it 'returns the correct account id' do
+        expect(method).to eq(expected_account_id)
+      end
+    end
+
+    context 'when the transfer is NO internal transfer' do
+      let(:payee_iban) { nil }
+
+      it 'returns the correct account id' do
+        expect(method).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Since today YNAB officially supports internal transactions between accounts through their api: https://support.youneedabudget.com/t/18pw4x

This PR adds tests and the required changes for internal transactions to work properly.

Depends on https://github.com/ynab/ynab-sdk-ruby/pull/29