### PR TITLE
Fall back to date in case entry_date is empty

### DIFF
--- a/lib/dumper/fints.rb
+++ b/lib/dumper/fints.rb
@@ -31,7 +31,7 @@ class Dumper
     end
 
     def date(transaction)
-      transaction.entry_date
+      transaction.entry_date || transaction.date
     end
 
     def payee_name(transaction)


### PR DESCRIPTION
Some banks only seem to fill the `date` attribute. In order to prevent a
NoMethodError in `to_ynab_transaction()` we should try both fields.

My bank initially would throw this error:
```
Traceback (most recent call last):
	7: from /usr/app/run.rb:9:in `<main>'
	6: from /usr/app/run.rb:9:in `map'
	5: from /usr/app/run.rb:11:in `block in <main>'
	4: from /usr/app/lib/account.rb:18:in `fetch_transactions'
	3: from /usr/app/lib/dumper/fints.rb:24:in `fetch_transactions'
	2: from /usr/app/lib/dumper/fints.rb:24:in `map'
	1: from /usr/app/lib/dumper/fints.rb:24:in `block in fetch_transactions'
/usr/app/lib/dumper.rb:19:in `to_ynab_transaction': undefined method `>' for nil:NilClass (NoMethodError)
```

I'm not very well versed in ruby, but enough that I could debug it by using the example code from the `ruby_fints` library. There I saw that `entry_date` was being returned as nil, while `date` did contain something. I just tried the solution you see in this PR in a local Docker container and it immediately worked. So please feel free to critique or adapt in any way that you consider proper or more correct. 🙂