### PR TITLE
Use correct JSON field in case returned error message is not valid JSON

### DIFF
--- a/lib/error_message.rb
+++ b/lib/error_message.rb
@@ -31,7 +31,7 @@ class ErrorMessage
   end
 
   def message
-    pretty_json || @e.message
+    pretty_json || @e.detail
   end
 
   def pretty_json


### PR DESCRIPTION
It seems that the YNAB API does not always return valid JSON in the `detail` field. The fallback seems to be trying to access the wrong JSON filed though in this case, so no further information is shown to the user. This PR changes the field used from `message` to `detail`.