### PR TITLE
Truncate the Payee field as the API limits it to 50 chars

### DIFF
--- a/lib/transaction_creator.rb
+++ b/lib/transaction_creator.rb
@@ -40,7 +40,10 @@ class TransactionCreator
 
     def payee_name(options)
       return nil if payee_id(options)
-      options.fetch(:payee_name, nil)
+      payee = options.fetch(:payee_name, nil)
+      # The api has a limit of 50 characters for the payee field
+      payee = truncate(payee, 50)
+      payee
     end
 
     def memo(options)


### PR DESCRIPTION
The YNAB API does not accept payee names longer than 50 chars. This PR adds a `truncate()` like #20 did for the `memo` field.