### PR TITLE
Fix digit-only usernames and passwords (fixes #34)

### DIFF
--- a/lib/dumper/fints.rb
+++ b/lib/dumper/fints.rb
@@ -7,8 +7,8 @@ class Dumper
 
     def initialize(params = {})
       @ynab_id  = params.fetch('ynab_id')
-      @username = params.fetch('username')
-      @password = params.fetch('password')
+      @username = params.fetch('username').to_s
+      @password = params.fetch('password').to_s
       @iban     = params.fetch('iban')
       @endpoint = params.fetch('fints_endpoint')
       @blz      = params.fetch('fints_blz')


### PR DESCRIPTION
If the username or password only contain digits, the ruby_fints library chokes because the YAML-parser returns the username/password as integer, while ruby_fints expects strings.