### PR TITLE
Introduce config flag for N26 to only import processed transactions

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -17,4 +17,5 @@ accounts:
     ynab_id: # last hash in the url when you click on the account in YNAB
     username: # n26 username
     password: # n26 password
+    skip_pending_transactions: false # default: false, only imports transactions when they're processed
     set_category: false # default: false, sets the N26 category name as category

--- a/lib/dumper/n26.rb
+++ b/lib/dumper/n26.rb
@@ -36,7 +36,7 @@ class Dumper
 
     def accept?(transaction)
       return true unless @skip_pending_transactions
-      alread_processed?(transaction)
+      already_processed?(transaction)
     end
 
     private
@@ -99,7 +99,7 @@ class Dumper
     # All very recent transactions with the credit card have
     # the type value set to "AA". So we assume that this is an
     # indicator to check if a transaction has been processed or not.
-    def alread_processed?(transaction)
+    def already_processed?(transaction)
       transaction['type'] != 'AA'
     end
   end

--- a/lib/dumper/n26.rb
+++ b/lib/dumper/n26.rb
@@ -88,24 +88,12 @@ class Dumper
     end
 
     def import_id(transaction)
-      data = [calculated_timestamp(transaction),
+      data = [transaction['visibleTS'],
               transaction['transactionNature'],
               transaction['amount'],
               transaction['accountId']].join
 
       Digest::MD5.hexdigest(data)
-    end
-
-    # N26 seems to have an internal timezone mismatch in their database.
-    # Transactions that are not processed yet have the `visibleTS` value
-    # in UTC but processed transactions have timezone Europe/Berlin.
-    # => This method checks if the transaction was processed or not.
-    #    If it's already processed it will just take the value, if not it will
-    #    add the current offset to make it Europe/Berlin timezone.
-    def calculated_timestamp(transaction)
-      return transaction['visibleTS'] if alread_processed?(transaction)
-      offset_to_utc = Time.now.in_time_zone('Europe/Berlin').utc_offset
-      transaction['visibleTS'] + offset_to_utc * 1000
     end
 
     # All very recent transactions with the credit card have

--- a/lib/dumper/n26.rb
+++ b/lib/dumper/n26.rb
@@ -17,6 +17,8 @@ class Dumper
       @password = params.fetch('password')
       @iban     = params.fetch('iban')
       @set_category = params.fetch('set_category', false)
+      @skip_pending_transactions = params.fetch('skip_pending_transactions',
+                                                false)
       @categories = {}
     end
 
@@ -28,8 +30,13 @@ class Dumper
       end
 
       client.transactions(count: 100)
-            .reject { |t| t['pending'] } # Only transactions that aren't pending
+            .select { |t| accept?(t) }
             .map { |t| to_ynab_transaction(t) }
+    end
+
+    def accept?(transaction)
+      return true unless @skip_pending_transactions
+      alread_processed?(transaction)
     end
 
     private

--- a/spec/dumper/n26_spec.rb
+++ b/spec/dumper/n26_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe Dumper::N26, vcr: vcr_options do
       end
     end
 
-    context 'when skip_pending_transactions feature is diabled' do
+    context 'when skip_pending_transactions feature is disabled' do
       let(:skip_pending_transactions) { true }
 
       context 'when the transaction is pending' do

--- a/spec/dumper/n26_spec.rb
+++ b/spec/dumper/n26_spec.rb
@@ -161,20 +161,6 @@ RSpec.describe Dumper::N26, vcr: vcr_options do
     it 'sets it correctly' do
       expect(method).to eq('46c9ccde424652bc013dca9b408dcdec')
     end
-
-    it 'is the same for a pending transaction and a processed transaction' do
-      expect(
-        object.send(:import_id, transaction_pending)
-      ).to eq(object.send(:import_id, transaction_processed))
-    end
-  end
-
-  describe '#calculated_timestamp' do
-    it 'is the same for a pending transaction and a processed transaction' do
-      expect(
-        object.send(:calculated_timestamp, transaction_pending)
-      ).to eq(object.send(:calculated_timestamp, transaction_processed))
-    end
   end
 
   describe '.accept?' do

--- a/spec/dumper/n26_spec.rb
+++ b/spec/dumper/n26_spec.rb
@@ -4,13 +4,15 @@ vcr_options = { cassette_name: 'dumper/n26',
 
 RSpec.describe Dumper::N26, vcr: vcr_options do
   subject(:object) { Dumper::N26.new(params) }
+  let(:skip_pending_transactions) { false }
 
   let(:params) do
     {
       'ynab_id' => '123466',
       'username' => 'username',
       'password' => 'password',
-      'iban' => 'DE89370400440532013000'
+      'iban' => 'DE89370400440532013000',
+      'skip_pending_transactions' => skip_pending_transactions
     }
   end
 
@@ -172,6 +174,48 @@ RSpec.describe Dumper::N26, vcr: vcr_options do
       expect(
         object.send(:calculated_timestamp, transaction_pending)
       ).to eq(object.send(:calculated_timestamp, transaction_processed))
+    end
+  end
+
+  describe '.accept?' do
+    subject(:accept?) { object.accept?(transaction) }
+
+    context 'when skip_pending_transactions feature is disabled' do
+      context 'when the transaction is pending' do
+        let(:transaction) { transaction_pending }
+
+        it 'returns true' do
+          expect(accept?).to be_truthy
+        end
+      end
+
+      context 'when the transaction is processed' do
+        let(:transaction) { transaction_processed }
+
+        it 'returns true' do
+          expect(accept?).to be_truthy
+        end
+      end
+    end
+
+    context 'when skip_pending_transactions feature is diabled' do
+      let(:skip_pending_transactions) { true }
+
+      context 'when the transaction is pending' do
+        let(:transaction) { transaction_pending }
+
+        it 'returns false' do
+          expect(accept?).to be_falsy
+        end
+      end
+
+      context 'when the transaction is processed' do
+        let(:transaction) { transaction_processed }
+
+        it 'returns true' do
+          expect(accept?).to be_truthy
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Background story 
Because the values that we get from the (not official) N26 API change from time to time, people often end up with duplicated transactions.

_There has already been [effort in avoiding that](https://github.com/schurig/ynab-bank-importer/pull/16) but it is still happening._

## What the PR will do
This PR will introduce a new config flag for the [N26 Dumper](https://github.com/schurig/ynab-bank-importer/wiki/n26) called `skip_pending_transactions`.

This setting will be set to `false` by default. When set to true, all transactions that are still pending _(= not processed by N26)_ won't be imported by the script until they are processed.

This will prevent duplicate entries but comes with the tradeoff that it might take a few days for transactions to show up in your YNAB.

The PR will fix #36.