### PR TITLE
Ignore refunds if it was only an credit card authorization

### DIFF
--- a/lib/dumper/n26.rb
+++ b/lib/dumper/n26.rb
@@ -36,7 +36,13 @@ class Dumper
 
     def accept?(transaction)
       return true unless @skip_pending_transactions
-      already_processed?(transaction)
+
+      # Card authorizations (if a company reserves some small amount)
+      # to check if your card is valid are the same type
+      # as processing transactions. So if we ignore those, we need to ignore
+      # the type for transactions where you get that authorization-money back.
+      already_processed?(transaction) &&
+        !returned_authorization?(transaction)
     end
 
     private
@@ -101,6 +107,12 @@ class Dumper
     # indicator to check if a transaction has been processed or not.
     def already_processed?(transaction)
       transaction['type'] != 'AA'
+    end
+
+    # This can be true if a company reserved some small money
+    # that they will give you back.
+    def returned_authorization?(transaction)
+      transaction['type'] == 'AV'
     end
   end
 end

--- a/spec/dumper/n26_spec.rb
+++ b/spec/dumper/n26_spec.rb
@@ -202,6 +202,19 @@ RSpec.describe Dumper::N26, vcr: vcr_options do
           expect(accept?).to be_truthy
         end
       end
+
+      context 'when the transaction is processed ' \
+              'but a returned authorization' do
+        let(:transaction) do
+          t = transaction_processed
+          t['type'] = 'AV'
+          t
+        end
+
+        it 'returns true' do
+          expect(accept?).to be_falsy
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem explained

The idea here is that when you ignore pending transactions, there might be credit card authorizations (where you will get back the money a few days later) which will be ignored if the N26 config flag `skip_pending_transactions` is set to `true`. But once you get the money back, those transactions will be processed and they might mess up your account balance.

## What this PR does

This PR will also ignore the transactions with the type `AV`, but only if the N26 config flag `skip_pending_transactions` is set to `true`.

This closes #44.

## Todo List

- [x] Write specs
- [ ] Validate that only those kind of transactions have the type `AV`