### PR TITLE
docker-compose.dev: bindmount the whole source tree

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,5 +4,5 @@ services:
     build:
       context: .
     volumes:
-      - ./config.yml:/usr/app/config.yml
+      - ./:/usr/app/
     command: "ruby /usr/app/run.rb"


### PR DESCRIPTION
So rebuilding the image isn't needed for development