### PR TITLE
Move away from deprecated BulkTransactions API

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -17,10 +17,10 @@ budget_id = Settings.all['ynab'].fetch('budget_id')
 access_token = Settings.all['ynab'].fetch('access_token')
 
 ynab_api = YNAB::API.new(access_token)
-bulk_transactions = YNAB::BulkTransactions.new(transactions: transactions)
 
 begin
-  ynab_api.transactions.bulk_create_transactions(budget_id, bulk_transactions)
+  ynab_api.transactions.create_transaction(budget_id,
+                                           transactions: transactions)
 rescue YNAB::ApiError => e
   ErrorMessage.new(e).print
   abort


### PR DESCRIPTION
The old API still works and might be supported, but it's in the
deprecated section of the docts and but POST to transactions should be
more "future-proof" according to the 2018-10-04 release notes:

https://www.youneedabudget.com/release-notes/#release_81452